### PR TITLE
do not give argv as main arguments

### DIFF
--- a/i3_workspace_names_daemon.py
+++ b/i3_workspace_names_daemon.py
@@ -366,7 +366,7 @@ def generate_icons(icons_json_path: str):
         _file.write('}\n')
 
 
-def main(argv) -> int:  # pylint: disable=redefined-outer-name
+def main() -> int:
     parser = argparse.ArgumentParser(__doc__)
     parser.add_argument(
         "-config-path",
@@ -439,7 +439,7 @@ def main(argv) -> int:  # pylint: disable=redefined-outer-name
               "For the mantainers of this program"),
         required=False,
     )
-    args = parser.parse_args(argv)
+    args = parser.parse_args()
 
     if args.generate_icons:
         generate_icons(args.generate_icons)
@@ -463,4 +463,4 @@ def main(argv) -> int:  # pylint: disable=redefined-outer-name
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(argv[1:])
+    main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,33 +1,39 @@
+import sys
+from unittest.mock import patch
+
 from i3_workspace_names_daemon import main
 from mocks import AttrDict, MockLeaf, MockWorkspace, MockTree, MockI3
 from pytest import raises
 import i3ipc
 
 
+@patch.object(sys, 'argv', ['i3_workspace_names_daemon', '-c', 'tests/test-config.json'])
 def test_main(monkeypatch):
     monkeypatch.setattr(i3ipc, 'Connection', lambda: MockI3(
         MockWorkspace(1, MockLeaf("firefox")),
         MockWorkspace(2, MockLeaf("chromium-browser")),
     ))
-    main(['-c', 'tests/test-config.json'])
+    main()
 
 
+@patch.object(sys, 'argv', ['i3_workspace_names_daemon', '-v', '-c', 'tests/test-config.json'])
 def test_verbose_startup(monkeypatch, capsys):
     monkeypatch.setattr(i3ipc, 'Connection', lambda: MockI3(
         MockWorkspace(1, MockLeaf("firefox")),
         MockWorkspace(2, MockLeaf("chromium-browser")),
     ))
-    main(['-v', '-c', 'tests/test-config.json'])
+    main()
     cap = capsys.readouterr()
     assert '-> name: firefox' in cap.out
     assert 'rename workspace "" to "1: "' in cap.out
 
 
+@patch.object(sys, 'argv', ['i3_workspace_names_daemon', '-c', 'asd'])
 def test_config(monkeypatch):
     monkeypatch.setattr(i3ipc, 'Connection', lambda: MockI3(
         MockWorkspace(1, MockLeaf("firefox")),
         MockWorkspace(2, MockLeaf("chromium-browser")),
     ))
     with raises(SystemExit) as ex:
-        main(['-c', 'asd'])
+        main()
     assert "Specified app-icon config path 'asd' does not exist" in str(ex)


### PR DESCRIPTION
Hi all!

Quick fix for installation via pip with git protocol.

Hope that helps!

--

Let argparse read sys.argv.
Use patch object for pytest to avoid modifying actual sys.argv.

Fixes #1.

Signed-off-by: Thomas Faivre <thomas.faivre@6wind.com>