### PR TITLE
Update testsuite

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install dependencies
@@ -35,6 +35,6 @@ jobs:
         coverage run -m pytest --cov=. --cov-report=xml
 
     - name: CodeCov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -35,6 +35,8 @@ jobs:
         coverage run -m pytest --cov=. --cov-report=xml
 
     - name: CodeCov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v4.0.1
       with:
         file: ./coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: i3-workspace-names-daemon/i3-workspace-names-daemon


### PR DESCRIPTION
adresses/potentially closes #16

codecov action introduced a [breaking change in v4](https://github.com/codecov/codecov-action/blob/v4.0.1/README.md#v4-release) which needs us to setup a secret token [like the one I mentioned](https://github.com/i3-workspace-names-daemon/i3-workspace-names-daemon/pull/12#issuecomment-1779439974) in PR #12 

As I do not have write permissions for neither the upstream repo nor the codecov repo, I cannot finish setting everything up. I would need someone (most likely @CastixGitHub) to follow [this guide](https://docs.codecov.com/docs/frequently-asked-questions#section-where-is-the-repository-upload-token-found-). I have been using the secret name `CODECOV_TOKEN` in the actions code. This is the name of the token, the script will be looking for.